### PR TITLE
Removed field 'track' to fix error

### DIFF
--- a/kubernetes/deployments/hello.yaml
+++ b/kubernetes/deployments/hello.yaml
@@ -6,8 +6,7 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-    app: hello
-    track: stable
+      app: hello
   template:
     metadata:
       labels:


### PR DESCRIPTION
The field 'track' is not recognized and gives error so it is removed.

$ kubectl create -f deployments/hello.yaml
error: error validating "deployments/hello.yaml": error validating data: [ValidationError(Deployment.spec.selector): unknown field "app" in io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector, ValidationError(Deployment.spec.selector): unknown field "track" in io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector]; if you choose to ignore these errors, turn validation off with --validate=false